### PR TITLE
`test_roundtrip_seekstart`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using CodecBase
 using Test
 using Random
 import TranscodingStreams:
+    TranscodingStreams,
     TranscodingStream,
     test_roundtrip_read,
     test_roundtrip_write,
@@ -66,6 +67,9 @@ end
     test_roundtrip_read(Base16EncoderStream, Base16DecoderStream)
     test_roundtrip_write(Base16EncoderStream, Base16DecoderStream)
     test_roundtrip_lines(Base16EncoderStream, Base16DecoderStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(Base16EncoderStream, Base16DecoderStream)
+    end
     test_roundtrip_transcode(Base16Encoder, Base16Decoder)
 end
 
@@ -117,6 +121,9 @@ end
     test_roundtrip_read(Base32EncoderStream, Base32DecoderStream)
     test_roundtrip_write(Base32EncoderStream, Base32DecoderStream)
     test_roundtrip_lines(Base32EncoderStream, Base32DecoderStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(Base32EncoderStream, Base32DecoderStream)
+    end
     test_roundtrip_transcode(Base32Encoder, Base32Decoder)
 end
 
@@ -167,5 +174,8 @@ end
     test_roundtrip_read(Base64EncoderStream, Base64DecoderStream)
     test_roundtrip_write(Base64EncoderStream, Base64DecoderStream)
     test_roundtrip_lines(Base64EncoderStream, Base64DecoderStream)
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(Base64EncoderStream, Base64DecoderStream)
+    end
     test_roundtrip_transcode(Base64Encoder, Base64Decoder)
 end


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session.

Ref: https://github.com/JuliaIO/TranscodingStreams.jl/issues/217