### PR TITLE
Bump compat for TranscodingStreams to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,13 +2,13 @@ name = "CodecBase"
 uuid = "6c391c72-fb7b-5838-ba82-7cfb1bcfecbf"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-TranscodingStreams = "0.9, 0.10"
+TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This update shouldn't affect the public API of this package. TranscodingStreams release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0